### PR TITLE
docs(README.md): Fixed link and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ apply-template templates/test-template my-target-dir --FULL_NAME="Patrick Scott"
 
 ## Templates
 
-* (meta-plugin)[https://github.com/patrickleet/meta-template-meta-plugin]
+* [meta-plugin](https://github.com/patrickleet/meta-template-meta-plugin)
 
-Please contibute more templates! It's super easy!
+Please contribute more templates! It's super easy!


### PR DESCRIPTION
Used correct markdown syntax for link "meta-plugin" and fixed typo in word "contribute".