### PR TITLE
Split on agnostic LineFeed

### DIFF
--- a/lib/gitignored.js
+++ b/lib/gitignored.js
@@ -7,7 +7,7 @@ module.exports.getGitignored = function (gitignorePath) {
 
   if (fs.existsSync(gitignorePath)) {
     gitignore = fs.readFileSync(gitignorePath, 'utf-8')
-    gitignored = gitignore.split('\n')
+    gitignored = gitignore.split('/\r\n|\r|\n/g')
   }
 
   gitignored.push('.git/')


### PR DESCRIPTION
Allows to split .gitingored file even when not using \n cahracter as a line feed (usefull for windows)