### PR TITLE
Fix/dont ignore git dir twice

### DIFF
--- a/lib/getFilesFromDir.js
+++ b/lib/getFilesFromDir.js
@@ -7,7 +7,7 @@ const getFilesFromDir = function *(directory) {
   const gitignorePath = path.join(directory, '.gitignore')
   const gitignoredArr = gitignored.getGitignored(gitignorePath)
 
-  return yield recursive(directory, ['.git', ...gitignoredArr]);
+  return yield recursive(directory, gitignoredArr);
 };
 
 module.exports = getFilesFromDir;

--- a/lib/gitignored.js
+++ b/lib/gitignored.js
@@ -7,7 +7,7 @@ module.exports.getGitignored = function (gitignorePath) {
 
   if (fs.existsSync(gitignorePath)) {
     gitignore = fs.readFileSync(gitignorePath, 'utf-8')
-    gitignored = gitignore.split('\n')
+    gitignored = gitignore.split('/\r\n|\r|\n/g')
   }
 
   gitignored.push('.git/')


### PR DESCRIPTION
Remove the unnecessary `.git` directory addition

It is already in the `gitignoredArr` array from the `gitignored.getGitignored()` output