### PR TITLE
Remove the unnecessary .git directory addition

### DIFF
--- a/lib/getFilesFromDir.js
+++ b/lib/getFilesFromDir.js
@@ -7,7 +7,7 @@ const getFilesFromDir = function *(directory) {
   const gitignorePath = path.join(directory, '.gitignore')
   const gitignoredArr = gitignored.getGitignored(gitignorePath)
 
-  return yield recursive(directory, ['.git', ...gitignoredArr]);
+  return yield recursive(directory, gitignoredArr);
 };
 
 module.exports = getFilesFromDir;


### PR DESCRIPTION
It is already in the gitignoredArr array from the gitignored.getGitignored() output